### PR TITLE
Breaking changes for v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,40 @@
 
 Terraform module to create Terraform drift, plan, and apply CodePipelines.
 
+## Resources Created
+
+- CodePipeline to run Terraform plan/apply operations. This pipeline contains a manual review step.
+- CodePipeline to run drift check on target resources. This pipeline is scheduled with a cron expression.
+- CodeBuld projects to support the CodePipelines
+- IAM Policies and Roles to support the CodePipelines
+- Notifications of Pipeline/Build status sent to Teams
+
 ## TO DO
 
 - Integrate the full script from `tf-plan.sh` into `buildspec.plan.tmpl.yml`. This script stops the pipeline when there are no changes to be applied.
-- Documentation!
 - Add configuration options. E.g., send notifications to existing SNS topic instead of creating a new one.
+- More documentation
 
 ## Change Log
-- 1.0.0
-  - Initial release that is lacking in documentation and subtlety. 
+
+### 2.0.0
+- added TF_LOGs configuration option
+- added `iam:GetPolicy` and `iam:GetPolicyVersion` privileges for the policies passed in as `resource_plan_policy_arns` and `resource_apply_policy_arns`
+- bump `tf-module-sns-teams-relay` version to 1.1.0
+- removed unused `environment` variable
+- rename `build_cron` variable to `drift_cron`
+- added minimal documentation
+
+### 1.0.0
+- Initial release that is lacking in documentation and subtlety
 
 ## Variables
 
-TBD
+See descriptions in `variables.tf`.
 
 ## Outputs
 
-TBD
+None.
 
 ## Example Use
 
@@ -40,7 +57,6 @@ module "apply_pipeline" {
   terraform_state_key    = "prod/tf-example/resources/terraform.state"
   github_repo = "CU-CommunityApps/tf-example"
   git_branch  = "main"
-  environment = "dev"
   resource_plan_policy_arns = [
     "arn:aws:iam::123456789012:policy/tf-example-plan-privs"
   ]

--- a/apply-pipeline.tf
+++ b/apply-pipeline.tf
@@ -117,6 +117,7 @@ resource "aws_codebuild_project" "build-plan" {
                   {
                     TERRAFORM_VERSION = var.terraform_version
                     RESOURCES_PATH    = var.resources_path
+                    tf_log            = var.tf_log
                   }
                 )
   }
@@ -159,6 +160,7 @@ resource "aws_codebuild_project" "build-apply" {
                   {
                     TERRAFORM_VERSION = var.terraform_version
                     RESOURCES_PATH    = var.resources_path
+                    tf_log            = var.tf_log
                   }
                 )
   }

--- a/buildspec.apply.tmpl.yml
+++ b/buildspec.apply.tmpl.yml
@@ -3,6 +3,9 @@ version: 0.2
 env:
   variables:
     TF_IN_AUTOMATION: true
+    %{ if tf_log != null }
+    TF_LOG: %{tf_log}
+    %{ endif }
 
 phases:
   install:

--- a/buildspec.apply.tmpl.yml
+++ b/buildspec.apply.tmpl.yml
@@ -4,7 +4,7 @@ env:
   variables:
     TF_IN_AUTOMATION: true
     %{ if tf_log != null }
-    TF_LOG: %{tf_log}
+    TF_LOG: ${tf_log}
     %{ endif }
 
 phases:

--- a/buildspec.check-drift.tmpl.yml
+++ b/buildspec.check-drift.tmpl.yml
@@ -3,6 +3,9 @@ version: 0.2
 env:
   variables:
     TF_IN_AUTOMATION: true
+    %{ if tf_log != null }
+    TF_LOG: %{tf_log}
+    %{ endif }
 
 phases:
   install:

--- a/buildspec.check-drift.tmpl.yml
+++ b/buildspec.check-drift.tmpl.yml
@@ -4,7 +4,7 @@ env:
   variables:
     TF_IN_AUTOMATION: true
     %{ if tf_log != null }
-    TF_LOG: %{tf_log}
+    TF_LOG: ${tf_log}
     %{ endif }
 
 phases:

--- a/buildspec.plan.tmpl.yml
+++ b/buildspec.plan.tmpl.yml
@@ -3,6 +3,9 @@ version: 0.2
 env:
   variables:
     TF_IN_AUTOMATION: true
+    %{ if tf_log != null }
+    TF_LOG: %{tf_log}
+    %{ endif }
 
 phases:
   install:

--- a/buildspec.plan.tmpl.yml
+++ b/buildspec.plan.tmpl.yml
@@ -4,7 +4,7 @@ env:
   variables:
     TF_IN_AUTOMATION: true
     %{ if tf_log != null }
-    TF_LOG: %{tf_log}
+    TF_LOG: ${tf_log}
     %{ endif }
 
 phases:

--- a/drift-pipeline.tf
+++ b/drift-pipeline.tf
@@ -75,6 +75,7 @@ resource "aws_codebuild_project" "build-drift" {
                   {
                     TERRAFORM_VERSION = var.terraform_version
                     RESOURCES_PATH    = var.resources_path
+                    tf_log            = var.tf_log
                   }
                 )
   }

--- a/drift-pipeline.tf
+++ b/drift-pipeline.tf
@@ -100,7 +100,7 @@ resource "aws_codebuild_project" "build-drift" {
 resource "aws_cloudwatch_event_rule" "build-drift-trigger" {
   name                = "${local.build_project_name_drift}-trigger"
   description         = "Trigger daily drift check"
-  schedule_expression = var.build_cron
+  schedule_expression = var.drift_cron
 }
 
 resource "aws_cloudwatch_event_target" "build-drift-trigger" {

--- a/notify.tf
+++ b/notify.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "sns-topic-policy" {
 }
 
 module "sns_teams_relay" {
-  source = "github.com/CU-CommunityApps/tf-module-sns-teams-relay.git?ref=v1.0.0"
+  source = "github.com/CU-CommunityApps/tf-module-sns-teams-relay.git?ref=v1.1.0"
   
   tags               = var.global_tags
   namespace          = var.namespace

--- a/shared.tf
+++ b/shared.tf
@@ -202,7 +202,7 @@ resource "aws_iam_policy" "build-policy" {
         "Action": [
             "iam:GetPolicy"
         ],
-        "Resource": ${var.resource_plan_policy_arns}
+        "Resource": ${jsonencode(var.resource_plan_policy_arns)}
     }
   ]
 }

--- a/shared.tf
+++ b/shared.tf
@@ -200,7 +200,8 @@ resource "aws_iam_policy" "build-policy" {
         "Sid": "IamReadPolicy",
         "Effect": "Allow",
         "Action": [
-            "iam:GetPolicy"
+            "iam:GetPolicy",
+            "iam:GetPolicyVersion"
         ],
         "Resource": ${jsonencode(var.resource_plan_policy_arns)}
     }

--- a/shared.tf
+++ b/shared.tf
@@ -266,6 +266,15 @@ resource "aws_iam_policy" "apply-policy" {
             "s3:PutObject"
         ],
         "Resource": "arn:aws:s3:::${var.terraform_state_bucket}/${var.terraform_state_key}"
+    },
+    {
+        "Sid": "IamReadPolicy",
+        "Effect": "Allow",
+        "Action": [
+            "iam:GetPolicy",
+            "iam:GetPolicyVersion"
+        ],
+        "Resource": ${jsonencode(var.resource_plan_policy_arns)}
     }
   ]
 }

--- a/shared.tf
+++ b/shared.tf
@@ -195,6 +195,14 @@ resource "aws_iam_policy" "build-policy" {
             "s3:PutObject"
         ],
         "Resource": "arn:aws:s3:::${var.terraform_state_bucket}/${var.terraform_state_key}"
+    },
+    {
+        "Sid": "IamReadPolicy",
+        "Effect": "Allow",
+        "Action": [
+            "iam:GetPolicy"
+        ],
+        "Resource": ${var.resource_plan_policy_arns}
     }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,71 +1,81 @@
 variable "teams_webhook_url" {
   type        = string
   sensitive   = true
+  description = "URL of the Teams webhook where notifications should be sent"
 }
 
 variable "github_codestarconnections_connection_arn" {
-  type    = string
+  type        = string
+  description = "ARN of the Github.com configuration that has read access to the git repo named in github_repo"
 }
 
 variable "namespace" {
-  type    = string
+  type        = string
+  description = "prefix used for naming resources created by this module"
 }
 
 variable "terraform_state_bucket" {
-  type    = string
+  type        = string
+  description = "name of the S3 bucket were Terraform remote state for the target resources can be found"
 }
 
 variable "terraform_state_key" {
-  type    = string
+  type        = string
+  description = "key/prefix of the S3 object holding Terraform remote state for the target resources"
 }
 
 variable "github_repo" {
-  type    = string
+  type        = string
+  description = "reference to the Github repo holding the target Terraform resource configuration; r.g., my-org/my-repo"
 }
 
 variable "git_branch" {
   type    = string
+  description = "git branch or tag in the repo holding the target Terraform resource configuration"
   default = "main"
 }
 
-variable "environment" {
-  type    = string
-  default = "production"
-}
-
 variable "global_tags" {
-  type    = map
-  default = {}
+  type        = map
+  description = "map of tags to be applied to all resources"
+  default     = {}
 }
 
 variable "terraform_version" {
-  type    = string
+  type        = string
+  description = "Terraform version required by the target resources"
 }
 
 variable "resources_path" {
-  type    = string
-  default = "resources/"
+  type        = string
+  description = "relative path of the target resources in the git repo"
+  default     = "resources/"
 }
 
-variable "build_cron" {
-  type    = string
-  default = "cron(0 12 * * ? *)"
+variable "drift_cron" {
+  type        = string
+  description = "AWS EventBridge cron expression for when drift should be checked"
+  default     = "cron(0 12 * * ? *)"
 }
 
 variable "resource_plan_policy_arns" {
-  type    = list(string)
+  type        = list(string)
+  description = "ARNs of IAM policies that support Terraform plan on the target resources"
 }
 
 variable "resource_apply_policy_arns" {
   type    = list(string)
+  description = "ARNs of IAM policies that support Terraform apply on the target resources"
 }
 
 variable "github_webhook_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  description = "Should the plan/apply pipeline be run when commits are made to the target branch?"
+  default     = false
 }
 
 variable "tf_log" {
-  type    = string
-  default = null
+  type        = string
+  description = "value for the TF_LOG variable in Terraform plan/apply operations"
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -64,3 +64,8 @@ variable "github_webhook_enabled" {
   type    = bool
   default = false
 }
+
+variable "tf_log" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
- added TF_LOGs configuration option
- added `iam:GetPolicy` and `iam:GetPolicyVersion` privileges for the policies passed in as `resource_plan_policy_arns` and `resource_apply_policy_arns`
- bump `tf-module-sns-teams-relay` version to 1.1.0
- removed unused `environment` variable
- rename `build_cron` variable to `drift_cron`
- added minimal documentation